### PR TITLE
feat(task-alias): add 'alias' config

### DIFF
--- a/lib/warlock/bootstrap.coffee
+++ b/lib/warlock/bootstrap.coffee
@@ -92,6 +92,11 @@ module.exports = ( options ) ->
     warlock.util.mout.object.forOwn metaTasks, ( deps, task ) ->
       warlock.task.add task, deps
 
+    # Now create alias tasks
+    aliases = warlock.config 'alias'
+    (Object.keys aliases).forEach ( key ) =>
+      warlock.task.add key, [].concat aliases[key]
+
     warlock.util.q true
   .then () ->
     # Ensure we have a default task defined, if none has been specified elsewhere

--- a/lib/warlock/bootstrap.coffee
+++ b/lib/warlock/bootstrap.coffee
@@ -93,7 +93,7 @@ module.exports = ( options ) ->
       warlock.task.add task, deps
 
     # Now create alias tasks
-    aliases = warlock.config 'alias'
+    aliases = warlock.config 'aliases'
     (Object.keys aliases).forEach ( key ) =>
       warlock.task.add key, [].concat aliases[key]
 

--- a/lib/warlock/config.coffee
+++ b/lib/warlock/config.coffee
@@ -26,6 +26,9 @@ _defaultConfig =
   # Tasks to inject into one of the flows.
   inject: []
 
+  # Task aliases - key is the name of the task alias, and the value is a string or array of strings
+  alias: {}
+
   # The default tasks to run when none are specified.
   default: []
 

--- a/lib/warlock/config.coffee
+++ b/lib/warlock/config.coffee
@@ -27,7 +27,7 @@ _defaultConfig =
   inject: []
 
   # Task aliases - key is the name of the task alias, and the value is a string or array of strings
-  alias: {}
+  aliases: {}
 
   # The default tasks to run when none are specified.
   default: []


### PR DESCRIPTION
Allow defining task aliases through an `alias` config. `alias` is an object, with the key being the name of the alias to define, and the value is either the task name to alias (string), or array of task name strings.

Example:

``` js
// warlock.json
"globs": {
   ...
}
"alias": {
   "b": "webapp-build",
   "bc": ["webapp-build", "webapp-compile"]
}
```
